### PR TITLE
Content length null check added in generateParameters method

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -33,7 +33,8 @@ Map<String, String> generateParameters(
   requestParams.addAll(mapParameters(request.url.queryParameters));
   requestParams.addAll(mapParameters(params));
   
-  if(request.contentLength != 0
+  if(request.contentLength != null
+      && request.contentLength != 0
       && ContentType.parse(request.headers["Content-Type"]).mimeType == "application/x-www-form-urlencoded") {
     requestParams.addAll(mapParameters(request.bodyFields));
   } 


### PR DESCRIPTION
We are using AngularDart's Http class to call rest services, in some cases we have to call services without passing any data to it. 
This Http class removes Content-Type header from request headers if data is "null" which makes sense. In oauth library there is condition in generateParameters method to check contentLength, I have modified it to check null value along with zero.