### PR TITLE
Upgrades to dependent packages with corresponding changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 0.4.0
+
+- updated to work with latest versions of packages like crypto
+- BREAKING: `generateParameters` now takes a `http` package `Request` object rather than 
+  a `BaseRequest`

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -10,7 +10,7 @@ import 'package:oauth/src/token.dart';
 import 'package:http/http.dart' as http;
 export 'package:oauth/src/token.dart' show Tokens;
 
-const Base64Codec _base64 = const Base64Codec.urlSafe();
+const Base64Codec _base64 = const Base64Codec();
 
 /** Generate the parameters to be included in the `Authorization:` header of a
  *  request. Generally you should prefer use of [signRequest] or [Client] 

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -2,19 +2,21 @@
  */
 library oauth.client;
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:oauth/src/utils.dart';
 import 'package:oauth/src/core.dart';
 import 'package:oauth/src/token.dart';
 import 'package:http/http.dart' as http;
-import 'package:crypto/crypto.dart' as crypto;
 export 'package:oauth/src/token.dart' show Tokens;
+
+const Base64Codec _base64 = const Base64Codec.urlSafe();
 
 /** Generate the parameters to be included in the `Authorization:` header of a
  *  request. Generally you should prefer use of [signRequest] or [Client] 
  */
 Map<String, String> generateParameters(
-    http.BaseRequest request,
+    http.Request request,
     Tokens tokens, 
     String nonce,
     int timestamp) {
@@ -40,7 +42,7 @@ Map<String, String> generateParameters(
   } 
   
   var sigBase = computeSignatureBase(request.method, request.url, requestParams);
-  params["oauth_signature"] = crypto.CryptoUtils.bytesToBase64(tokens.sign(sigBase));
+  params["oauth_signature"] = _base64.encode(tokens.sign(sigBase));
   
   return params;
 }
@@ -97,7 +99,7 @@ class Client extends http.BaseClient {
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {
       var nonce = getRandomBytes(8);
-      String nonceStr = crypto.CryptoUtils.bytesToBase64(nonce, urlSafe: true);
+      String nonceStr = _base64.encode(nonce);
       signRequest(request, tokens, nonceStr,
                   new DateTime.now().millisecondsSinceEpoch ~/ 1000);
       return _client.send(request);

--- a/lib/server.dart
+++ b/lib/server.dart
@@ -2,7 +2,6 @@
 library oauth.server;
 import 'dart:async';
 import 'dart:convert';
-import 'package:crypto/crypto.dart';
 import 'package:oauth/src/token.dart';
 import 'package:oauth/src/core.dart';
 import 'package:oauth/src/utils.dart';
@@ -153,6 +152,6 @@ Future<bool> isAuthorized(RequestAdapter request,
     }
   }).then((List<Parameter> reqParams) {   
     List<int> sigBase = computeSignatureBase(request.method, request.requestedUri, reqParams);
-    return tokens.verify(CryptoUtils.base64StringToBytes(signature), sigBase);
+    return tokens.verify(const Base64Codec.urlSafe().decode(signature), sigBase);
   }).catchError((_) => false, test: (e) => e is _NotAuthorized);
 }

--- a/lib/server_shelf.dart
+++ b/lib/server_shelf.dart
@@ -49,14 +49,7 @@ class ShelfRequestAdapter implements RequestAdapter {
   /// Must be called after the isAuthorized call has completed.
   Request getRequest() {
     if(didReadBody) {
-      return new Request(
-          _request.method, _request.requestedUri, 
-          body:            _body, 
-          context:         _request.context,
-          headers:         _request.headers, 
-          protocolVersion: _request.protocolVersion, 
-          scriptName:      _request.scriptName, 
-          url:             _request.url);
+      return _request.change(body: _body);
     } else {
       return _request;
     }

--- a/lib/src/token.dart
+++ b/lib/src/token.dart
@@ -8,6 +8,8 @@ import 'package:cipher/random/secure_random_base.dart';
 import 'package:bignum/bignum.dart';
 import 'core.dart';
 
+const Base64Codec _base64 = const Base64Codec.urlSafe();
+
 /// Bundles together the public and secret portions of an OAuth token pair.
 abstract class Tokens {
   /// The token (public) ID
@@ -87,9 +89,8 @@ class HmacSha1Tokens extends Tokens {
   
   List<int> sign(List<int> value) {
     var secret = _computeKey();    
-    var mac = new crypto.HMAC(new crypto.SHA1(), secret);
-    mac.add(value);
-    return mac.close();
+    var mac = new crypto.Hmac(crypto.sha1, secret);
+    return mac.convert(value);
   }
   
   bool verify(List<int> signature, List<int> value) {
@@ -107,7 +108,7 @@ class HmacSha1Tokens extends Tokens {
 }
 
 BigInteger _b64bigint(String str) {
-  return new BigInteger(crypto.CryptoUtils.base64StringToBytes(str));
+  return new BigInteger(_base64.decode(str));
 }
 
 bool _checkContains(Map map, List params, String error, bool need) {

--- a/lib/src/token.dart
+++ b/lib/src/token.dart
@@ -90,7 +90,7 @@ class HmacSha1Tokens extends Tokens {
   List<int> sign(List<int> value) {
     var secret = _computeKey();    
     var mac = new crypto.Hmac(crypto.sha1, secret);
-    return mac.convert(value);
+    return mac.convert(value).bytes;
   }
   
   bool verify(List<int> signature, List<int> value) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: oauth
-version: 0.3.0
+version: 0.4.0
 author: Owen Shepherd <*@owenshepherd.net>
 description: An implementation of OAuth 1.0a per RFC 5849
 homepage: https://github.com/oshepherd/oauth.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ description: An implementation of OAuth 1.0a per RFC 5849
 homepage: https://github.com/oshepherd/oauth.dart
 dependencies:
   cipher: '>=0.7.0 <0.8.0'
-  crypto: '>=0.9.0 <0.10.0'
+  crypto: '^2.0.1'
   http: '>=0.10.0 <0.12.0'
 dev_dependencies:
-  shelf: any
-  unittest: '>=0.10.0 <0.11.0'
+  shelf: '>=0.6.7+2'
+  test: '>=0.10.0'

--- a/test/_server_test.dart
+++ b/test/_server_test.dart
@@ -3,7 +3,7 @@ library oauth.test.common;
 import 'dart:io';
 import 'dart:async';
 import 'package:oauth/oauth.dart' as oauth;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 simpleNonceQuery(String consumerToken, String userToken, 
     String nonce, DateTime expiry) {

--- a/test/_server_test.dart
+++ b/test/_server_test.dart
@@ -27,30 +27,21 @@ simpleTokenFinder(String type, String consumer, String user) {
 
 runAllTests(String authority) {
   standardTests(oauth.Client goodClient) => () {
-    test("Simple GET", () {
-      var done = expectAsync((_) {});    
-  
-      goodClient.get(new Uri.http(authority, "/test/path", {"foo":"bar"})).then((response) {
-        expect(response.statusCode, HttpStatus.OK);
-      }).then(done);
+    test("Simple GET", () async {
+      var response = await goodClient.get(new Uri.http(authority, "/test/path", {"foo":"bar"}));
+      expect(response.statusCode, HttpStatus.OK);
     });
     
-    test("Simple POST", () {
-      var done = expectAsync((_) {});
-      
-      goodClient.post(new Uri.http(authority, "/test/path"), body: "Hello, World!").then((response) {
-        expect(response.statusCode, HttpStatus.OK);      
-      }).then(done);
+    test("Simple POST", () async {
+      var response = await goodClient.post(new Uri.http(authority, "/test/path"), body: "Hello, World!");
+      expect(response.statusCode, HttpStatus.OK);
     });
     
-    test("Form Data POST", () {
-      var done = expectAsync((_) {});
-      
-      goodClient.post(new Uri.http(authority, "/test/path", {"c":"4"}), 
+    test("Form Data POST", () async {
+      var response = await goodClient.post(new Uri.http(authority, "/test/path", {"c":"4"}),
           body: "a=1&b=2&c=3",
-          headers: {"Content-Type": "application/x-www-form-urlencoded"}).then((response) {
-        expect(response.statusCode, HttpStatus.OK);      
-      }).then(done);    
+          headers: {"Content-Type": "application/x-www-form-urlencoded"});
+      expect(response.statusCode, HttpStatus.OK);
     });
   };
   
@@ -60,12 +51,9 @@ runAllTests(String authority) {
   group("With user credentials",
       standardTests(new oauth.Client(new oauth.Tokens(consumerId: "Hello", consumerKey: "HELLO", userId: "World", userKey: "WORLD"))));
   
-  test("Bad GET", () {
-    var done = expectAsync((_) {});
-    
+  test("Bad GET", () async {
     var client = new oauth.Client(new oauth.Tokens(consumerId: "bad", consumerKey: "very very bad"));
-    client.get(new Uri.http(authority,  "/")).then((response) {
-      expect(response.statusCode, HttpStatus.FORBIDDEN);
-    }).then(done);
+    var response = await client.get(new Uri.http(authority,  "/"));
+    expect(response.statusCode, HttpStatus.FORBIDDEN);
   });
 }

--- a/test/crypto_test.dart
+++ b/test/crypto_test.dart
@@ -1,6 +1,6 @@
 import 'package:oauth/client.dart' as oauth;
 import 'package:http/http.dart' as http;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 void main() {
   test("GET secret", () {

--- a/test/crypto_test.dart
+++ b/test/crypto_test.dart
@@ -14,6 +14,6 @@ void main() {
     var req = new http.Request("GET", Uri.parse("http://example.com/?a=1&b=2"));
     var params = oauth.generateParameters(req, tokens, nonce, 1398030869);
     
-    expect(params['oauth_signature'] == "SUmV0pnBNRvm57z69++0qAlg5Qk=", true);
+    expect(params['oauth_signature'], equals("SUmV0pnBNRvm57z69++0qAlg5Qk="));
   });
 }

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:io';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:oauth/oauth.dart' as oauth;
 import 'package:oauth/server_io.dart';
 import '_server_test.dart';

--- a/test/shelf_test.dart
+++ b/test/shelf_test.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:oauth/oauth.dart' as oauth;
 import 'package:oauth/server_shelf.dart';
 import '_server_test.dart';


### PR DESCRIPTION
Much has changed in the dependencies (including sdk) since this was last published.

Some of the bigger changes:

* `crypto` package was completely reworked
* `test` package replaced `unittest`
* `expectAsync` is deprecated and its use seemed to break tests. Replaced with `async/await`